### PR TITLE
modmod: Don't add empty slice if slides.md is empty

### DIFF
--- a/modmod/src/slides.rs
+++ b/modmod/src/slides.rs
@@ -95,11 +95,13 @@ impl<'track> SlidesPackage<'track> {
                 let topic_content = section.content.read_to_string()?;
                 let topic_content = topic_content.trim();
 
-                if !topic_content.starts_with("---") {
-                    unit_content.write_str("---\n\n").unwrap();
+                if !topic_content.is_empty() {
+                    if !topic_content.starts_with("---") {
+                        unit_content.write_str("---\n\n").unwrap();
+                    }
+                    unit_content.write_str(topic_content).unwrap();
+                    unit_content.write_str("\n").unwrap();
                 }
-                unit_content.write_str(topic_content).unwrap();
-                unit_content.write_str("\n").unwrap();
 
                 for objective in section.objectives.iter() {
                     unit_objectives += &format!("- {}\n", objective.trim());


### PR DESCRIPTION
Modmod tool was adding an empty slide if `slides.md` was empty. This is the case for the topic `mods/0-intro/topics/setup`.

This commit check if the slide contents is empty after trimming it and doesn't write anything. Before it was writing `---` which was introducing an empty slide in the final Slidev Markdown file.