### PR TITLE
modmod: Bump Slidev version

### DIFF
--- a/modmod/include/slides/package.json
+++ b/modmod/include/slides/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@slidev/cli": "^0.42",
+    "@slidev/cli": "^0.48",
     "@slidev/theme-default": "*",
     "@slidev/theme-seriph": "*",
     "slidev-theme-101-rs": "0.0.2"


### PR DESCRIPTION
Slidev version 0.48.X brings some useful features as Notes with clicks sliders and notes marker, see the full list at
https://github.com/slidevjs/slidev/releases/tag/v0.48.0

After checking the slides for some of the modules and the changelog from the v0.42.X until the v0.48.X, I assumed that any of the breaking changes reported in the changelog affects the presentations that this course contains.

The only thing that I saw that it could be a potential issues was that v0.43.0 (https://github.com/slidevjs/slidev/releases/tag/v0.43.0) requires NodeJS 18 or newer, however, I didn't find any reference in the repository about that certain NodeJS version is required, so I assumed that it wasn't a change that affects this course.