### PR TITLE
modmod improvements

### DIFF
--- a/modmod/src/lib.rs
+++ b/modmod/src/lib.rs
@@ -36,6 +36,7 @@ impl Track {
     pub fn render(
         &self,
         output_dir: impl AsRef<Path>,
+        slide_url_base: &str,
         clear_output: bool,
     ) -> Result<(), LoadTrackError> {
         let output_dir = output_dir.as_ref();
@@ -92,7 +93,7 @@ impl Track {
         // Build and render the slides package
         let slides_package = slides_builder.build();
         slides_package
-            .render(output_dir)
+            .render(output_dir, slide_url_base)
             .change_context(LoadTrackError)?;
 
         Ok(())

--- a/modmod/src/main.rs
+++ b/modmod/src/main.rs
@@ -14,6 +14,11 @@ struct Args {
     #[arg(short = 'c', long = "clear", help = "Clear the output folder")]
     clear_output_dir: bool,
     track_toml_path: PathBuf,
+    #[arg(
+        long,
+        help = "Use this as a base when deploying the slides to a web server"
+    )]
+    slide_url_base: Option<String>,
 }
 
 fn main() {
@@ -24,9 +29,14 @@ fn main() {
             output_dir,
             clear_output_dir,
             track_toml_path,
+            slide_url_base,
         } = args;
         let track = modmod::Track::load_toml_def(track_toml_path)?;
-        track.render(output_dir, clear_output_dir)?;
+        track.render(
+            output_dir,
+            slide_url_base.as_deref().unwrap_or("/"),
+            clear_output_dir,
+        )?;
         Ok(())
     }
 

--- a/modmod/src/slides.rs
+++ b/modmod/src/slides.rs
@@ -64,11 +64,8 @@ impl<'track> SlidesPackage<'track> {
 
         for deck in self.decks.iter() {
             let deck_prefix = format!("{}_{}", deck.module_index, deck.unit_index);
-            let deck_output = {
-                let mut o = slides_output_dir.join(to_prefixed_tag(deck.name, &deck_prefix));
-                o.set_extension("md");
-                o
-            };
+            let deck_slug = to_prefixed_tag(deck.name, &deck_prefix);
+            let deck_output = slides_output_dir.join(&deck_slug).with_extension("md");
             let mut deck_file = deck_output.create_file()?;
 
             {
@@ -85,7 +82,7 @@ impl<'track> SlidesPackage<'track> {
 
                 package_scripts.insert(
                     format!("build-{deck_prefix}"),
-                    format!("slidev build --out dist/{deck_prefix} --base /{url_base}{url_base_separator}slides/{deck_prefix}/ {deck_output_str}")
+                    format!("slidev build --out dist/{deck_slug} --base /{url_base}{url_base_separator}slides/{deck_slug}/ {deck_output_str}")
                         .into(),
                 );
                 package_scripts.insert(

--- a/modmod/src/slides.rs
+++ b/modmod/src/slides.rs
@@ -44,7 +44,11 @@ impl<'track> SlidesPackage<'track> {
         }
     }
 
-    pub fn render(&self, out_dir: impl AsRef<Path>) -> Result<(), RenderSlidesError> {
+    pub fn render(
+        &self,
+        out_dir: impl AsRef<Path>,
+        url_base: &str,
+    ) -> Result<(), RenderSlidesError> {
         let mut package_json: JsonObject = serde_json::from_str(PACKAGE_JSON_CONTENT_STUB).unwrap();
         package_json.insert("name".into(), to_tag(self.name).into());
         let mut package_scripts = JsonObject::new();
@@ -55,6 +59,8 @@ impl<'track> SlidesPackage<'track> {
 
         let slide_images_dir = slides_output_dir.join("images");
         slide_images_dir.create_dir_all()?;
+        let url_base = url_base.trim_matches('/');
+        let url_base_separator = if url_base.is_empty() { "" } else { "/" };
 
         for deck in self.decks.iter() {
             let deck_prefix = format!("{}_{}", deck.module_index, deck.unit_index);
@@ -79,7 +85,7 @@ impl<'track> SlidesPackage<'track> {
 
                 package_scripts.insert(
                     format!("build-{deck_prefix}"),
-                    format!("slidev build --out dist/{deck_prefix} --base /slides/{deck_prefix}/ {deck_output_str}")
+                    format!("slidev build --out dist/{deck_prefix} --base /{url_base}{url_base_separator}slides/{deck_prefix}/ {deck_output_str}")
                         .into(),
                 );
                 package_scripts.insert(


### PR DESCRIPTION
This PR consists of 3 commits:
- Make the base url for slides configurable via CLI
- Change the slide output folders so they contain a human readable slug (this makes it easier to find specific slides when presenting)
- When "rendering" slides with modmod, skip slides which do neither have content nor objectives nor summary

If you do not like any of the changes, let me know - will remove the corresponding commit from the PR!